### PR TITLE
Install protobuf through apt-get instead of pip

### DIFF
--- a/install/scripts/base.sh
+++ b/install/scripts/base.sh
@@ -67,8 +67,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   valgrind \
   wget \
   xterm \
-  xz-utils
-
-sudo pip install protobuf
+  xz-utils \
+  python3-protobuf
 
 # vi: ts=2 sw=2 et


### PR DESCRIPTION
Add python3-protobuf to the existing apt-get install command, instead of installing it with pip