### PR TITLE
Add http file path for electrode_rviz package.

### DIFF
--- a/read_only/dream/base.yaml
+++ b/read_only/dream/base.yaml
@@ -36,6 +36,10 @@ repositories:
     type: git
     url: https://github.com/CogniPilot/electrode
     version: main
+  electrode/src/electrode_rviz:
+    type: git
+    url: https://github.com/CogniPilot/electrode_rviz
+    version: main
   ws/cerebri:
     type: git
     url: https://github.com/CogniPilot/cerebri


### PR DESCRIPTION
Add http path for electrode_rviz package in base.yaml. The ssh path was already added in the last commit.